### PR TITLE
Fixups

### DIFF
--- a/def.cf
+++ b/def.cf
@@ -24,9 +24,6 @@ bundle common def
       "augments_are_json" expression => regcmp(".+\.json", $(augments_file)), scope => "bundle";
       "have_json_augments" and => { "have_augments_file", "augments_are_json" }, scope => "bundle";
 
-      "augments_are_yaml" expression => regcmp(".+\.yaml", $(augments_file)), scope => "bundle";
-      "have_yaml_augments" and => { "have_augments_file", "augments_are_yaml" }, scope => "bundle";
-
       "have_roles" expression => isvariable("augments[roles]"), scope => "bundle";
       "have_inputs" expression => isvariable("augments[inputs]"), scope => "bundle";
 
@@ -37,8 +34,7 @@ bundle common def
   vars:
 
     any::
-      "augments_file" string => ifelse(fileexists("$(this.promise_dirname)/services/def.yaml"), "$(this.promise_dirname)/services/def.yaml",
-                                      "$(this.promise_dirname)/services/def.json");
+      "augments_file" string => "$(this.promise_dirname)/services/def.json";
 
       "defvars" slist => variablesmatching("default:def\..*", "defvar");
 
@@ -46,7 +42,6 @@ bundle common def
 
     have_augments_file::
       "augments" data => readjson($(augments_file), 100k), ifvarclass => "augments_are_json";
-      "augments" data => readyaml($(augments_file), 100k), ifvarclass => "augments_are_yaml";
 
       "extra_inputs" slist => getvalues("augments[inputs]");
       "override_vars" slist => getindices("augments[vars]");

--- a/def.cf
+++ b/def.cf
@@ -13,9 +13,6 @@ bundle common def
 
 {
   classes:
-      # all extra classes are defined true
-      "$(extra_classes)" expression => "any", meta => { "extra" };
-
       # all override classes are defined true
       "$(override_classes)" expression => "any", meta => { "override" };
 
@@ -23,6 +20,9 @@ bundle common def
 
       "augments_are_json" expression => regcmp(".+\.json", $(augments_file)), scope => "bundle";
       "have_json_augments" and => { "have_augments_file", "augments_are_json" }, scope => "bundle";
+
+      "augments_are_yaml" expression => regcmp(".+\.yaml", $(augments_file)), scope => "bundle";
+      "have_yaml_augments" and => { "have_augments_file", "augments_are_yaml" }, scope => "bundle";
 
       "have_roles" expression => isvariable("augments[roles]"), scope => "bundle";
       "have_inputs" expression => isvariable("augments[inputs]"), scope => "bundle";
@@ -34,14 +34,14 @@ bundle common def
   vars:
 
     any::
-      "augments_file" string => "$(this.promise_dirname)/services/def.json";
+      "augments_file" string => ifelse(fileexists("$(this.promise_dirname)/services/def.yaml"), "$(this.promise_dirname)/services/def.yaml",
+                                      "$(this.promise_dirname)/services/def.json");
 
       "defvars" slist => variablesmatching("default:def\..*", "defvar");
 
-      "extra_classes" slist => readstringlist("$(this.promise_dirname)/services/extra_classes.txt", "#.*", "\s", 10k, 100k);
-
     have_augments_file::
       "augments" data => readjson($(augments_file), 100k), ifvarclass => "augments_are_json";
+      #"augments" data => readyaml($(augments_file), 100k), ifvarclass => "augments_are_yaml";
 
       "extra_inputs" slist => getvalues("augments[inputs]");
       "override_vars" slist => getindices("augments[vars]");
@@ -323,20 +323,19 @@ bundle common def
                     issues.";
 
   reports:
-    verbose_mode::
-      "$(this.bundle): override request $(override_vars) to '$(override_data_s_$(override_vars))'; new value '$($(override_vars))'"
+    DEBUG|DEBUG_def::
+      "DEBUG: $(this.bundle)";
+      "$(const.t) override request $(override_vars) to '$(override_data_s_$(override_vars))'; new value '$($(override_vars))'"
       ifvarclass => isvariable("override_data_$(override_vars)");
 
-      "$(this.bundle): extra class $(extra_classes)";
-
-      "$(this.bundle): defined class role/byname $(extra_roles[byname][$(roles_byname_keys)]) because of classmatch('$(roles_byname_keys)')"
+      "$(const.t) defined class role/byname $(extra_roles[byname][$(roles_byname_keys)]) because of classmatch('$(roles_byname_keys)')"
       ifvarclass => "$(extra_roles[byname][$(roles_byname_keys)])";
 
-      "$(this.bundle): defined class role/byrole $(roles_byrole_keys) because of classmatch('$(extra_roles[byrole][$(roles_byrole_keys)])')"
+      "$(const.t) defined class role/byrole $(roles_byrole_keys) because of classmatch('$(extra_roles[byrole][$(roles_byrole_keys)])')"
       ifvarclass => "$(roles_byrole_keys)";
 
-      "$(this.bundle): override class $(override_classes)";
-      "$(this.bundle): $(defvars) = $($(defvars))";
+      "$(const.t) override class $(override_classes)";
+      "$(const.t) $(defvars) = $($(defvars))";
 }
 
 bundle common inventory_control

--- a/services/extra_classes.txt
+++ b/services/extra_classes.txt
@@ -1,2 +1,0 @@
-# just uncomment the below to enable autorun
-# services_autorun

--- a/update.cf
+++ b/update.cf
@@ -61,7 +61,7 @@ bundle common update_def
     any::
       "augments_file" string => "$(this.promise_dirname)/services/def.json";
 
-      "defvars" slist => variablesmatching("default:def\..*", "defvar");
+      "defvars" slist => variablesmatching("default:update_def\..*", "defvar");
 
       "extra_classes" slist => readstringlist("$(this.promise_dirname)/services/extra_classes.txt", "#.*", "\s", 10k, 100k);
 

--- a/update.cf
+++ b/update.cf
@@ -55,14 +55,11 @@ bundle common update_def
       "augments_are_json" expression => regcmp(".+\.json", $(augments_file)), scope => "bundle";
       "have_json_augments" and => { "have_augments_file", "augments_are_json" }, scope => "bundle";
 
-      "augments_are_yaml" expression => regcmp(".+\.yaml", $(augments_file)), scope => "bundle";
-      "have_yaml_augments" and => { "have_augments_file", "augments_are_yaml" }, scope => "bundle";
 
   vars:
       "current_version" string => "3.7.0";
     any::
-      "augments_file" string => ifelse(fileexists("$(this.promise_dirname)/services/def.yaml"), "$(this.promise_dirname)/services/def.yaml",
-                                      "$(this.promise_dirname)/services/def.json");
+      "augments_file" string => "$(this.promise_dirname)/services/def.json";
 
       "defvars" slist => variablesmatching("default:def\..*", "defvar");
 
@@ -70,7 +67,6 @@ bundle common update_def
 
     have_augments_file::
       "augments" data => readjson($(augments_file), 100k), ifvarclass => "augments_are_json";
-      "augments" data => readyaml($(augments_file), 100k), ifvarclass => "augments_are_yaml";
 
       "override_vars" slist => getindices("augments[vars]");
       "override_classes" slist => getvalues("augments[classes]");

--- a/update.cf
+++ b/update.cf
@@ -44,9 +44,6 @@ body agent control
 bundle common update_def
 {
   classes:
-      # all extra classes are defined true
-      "$(extra_classes)" expression => "any", meta => { "extra" };
-
       # all override classes are defined true
       "$(override_classes)" expression => "any", meta => { "override" };
 
@@ -62,8 +59,6 @@ bundle common update_def
       "augments_file" string => "$(this.promise_dirname)/services/def.json";
 
       "defvars" slist => variablesmatching("default:update_def\..*", "defvar");
-
-      "extra_classes" slist => readstringlist("$(this.promise_dirname)/services/extra_classes.txt", "#.*", "\s", 10k, 100k);
 
     have_augments_file::
       "augments" data => readjson($(augments_file), 100k), ifvarclass => "augments_are_json";
@@ -195,8 +190,6 @@ bundle common update_def
     verbose_mode::
       "$(this.bundle): override request $(override_vars) to '$(override_data_s_$(override_vars))'; new value '$($(override_vars))'"
       ifvarclass => isvariable("override_data_$(override_vars)");
-
-      "$(this.bundle): extra class $(extra_classes)";
 
       "$(this.bundle): override class $(override_classes)";
       "$(this.bundle): $(defvars) = $($(defvars))";


### PR DESCRIPTION
Remove: Extra classes

```
The same functionality is provided by the override classes since they are
all defined. Removed for simplification and reduced complexity.

Fix: Where to look for defvars

Need to look in the update_def bundle for update related defvars.

Remove: Yaml support

Having too many options adds too much complexity.
```
