### PR TITLE
Change: Split def.cf into lib/VER

### DIFF
--- a/lib/3.5/def.cf
+++ b/lib/3.5/def.cf
@@ -4,32 +4,11 @@
 #  - common/global variables and classes here
 #
 ###############################################################################
-body file control
-{
-      inputs => { @(def.extra_inputs) };
-}
-
 bundle common def
 
 {
   classes:
-      # all override classes are defined true
-      "$(override_classes)" expression => "any", meta => { "override" };
-
       "have_augments_file" expression => fileexists($(augments_file)), scope => "bundle";
-
-      "augments_are_json" expression => regcmp(".+\.json", $(augments_file)), scope => "bundle";
-      "have_json_augments" and => { "have_augments_file", "augments_are_json" }, scope => "bundle";
-
-      "augments_are_yaml" expression => regcmp(".+\.yaml", $(augments_file)), scope => "bundle";
-      "have_yaml_augments" and => { "have_augments_file", "augments_are_yaml" }, scope => "bundle";
-
-      "have_roles" expression => isvariable("augments[roles]"), scope => "bundle";
-      "have_inputs" expression => isvariable("augments[inputs]"), scope => "bundle";
-
-    have_roles::
-      "$(extra_roles[byname][$(roles_byname_keys)])" expression => classmatch("$(roles_byname_keys)"), meta => { "role" };
-      "$(roles_byrole_keys)" expression => classmatch("$(extra_roles[byrole][$(roles_byrole_keys)])"), meta => { "role" };
 
   vars:
 
@@ -37,56 +16,19 @@ bundle common def
       "augments_file" string => ifelse(fileexists("$(this.promise_dirname)/services/def.yaml"), "$(this.promise_dirname)/services/def.yaml",
                                       "$(this.promise_dirname)/services/def.json");
 
-      "defvars" slist => variablesmatching("default:def\..*", "defvar");
-
-    have_augments_file::
-      "augments" data => readjson($(augments_file), 100k), ifvarclass => "augments_are_json";
-      #"augments" data => readyaml($(augments_file), 100k), ifvarclass => "augments_are_yaml";
-
-      "extra_inputs" slist => getvalues("augments[inputs]");
-      "override_vars" slist => getindices("augments[vars]");
-      "override_classes" slist => getvalues("augments[classes]");
-      "override_data_$(override_vars)" data => mergedata("augments[vars][$(override_vars)]");
-      "override_data_s_$(override_vars)" string => format("%S", "override_data_$(override_vars)");
-
-    !have_augments_file::
-      "extra_inputs" slist => {};
-
-    have_roles::
-      "extra_roles" data => mergedata("augments[roles]");
-      "roles_byname_keys" slist => getindices("extra_roles[byname]");
-      "roles_byrole_keys" slist => getindices("extra_roles[byrole]");
-
-    any::
-      # Begin change
-
       # Your domain name, for use in access control
-      "domain"  string => ifelse(isvariable("override_data_domain"), "$(override_data_domain)",
-                                "$(sys.domain)"), # this default may be inaccurate!
+      "domain"  string => "$(sys.domain)", # this default may be inaccurate!
       comment => "Define a global domain for all hosts",
-      handle => "common_def_vars_domain",
-      meta => { "defvar" };
+      handle => "common_def_vars_domain";
 
       # Mail settings used by body executor control found in controls/cf_execd.cf
-      "mailto" string => ifelse(isvariable("override_data_mailto"), "$(override_data_mailto)",
-                               "root@$(def.domain)"),
-      meta => { "defvar" };
+      "mailto" string => "root@$(def.domain)";
 
-      "mailfrom" string => ifelse(isvariable("override_data_mailfrom"), "$(override_data_mailfrom)",
-                                 "root@$(sys.uqhost).$(def.domain)"),
-      meta => { "defvar" };
+      "mailfrom" string => "root@$(sys.uqhost).$(def.domain)";
 
-      "smtpserver" string => ifelse(isvariable("override_data_smtpserver"), "$(override_data_smtpserver)",
-                                   "localhost"),
-      meta => { "defvar" };
+      "smtpserver" string => "localhost";
 
       # List here the IP masks that we grant access to on the server
-
-      "acl"     slist => getvalues("override_data_acl"),
-      comment => "JSON-sourced: Define an acl for the machines to be granted accesses",
-      handle => "common_def_json_vars_acl",
-      ifvarclass => isvariable("override_data_acl"),
-      meta => { "defvar" };
 
       "acl"     slist => {
                            # Allow everything in my own domain.
@@ -104,27 +46,18 @@ bundle common def
                            #  "217.77.34.19",
       },
       comment => "Define an acl for the machines to be granted accesses",
-      handle => "common_def_vars_acl",
-      ifvarclass => not(isvariable("override_data_acl")),
-      meta => { "defvar" };
+      handle => "common_def_vars_acl";
 
       # Out of the hosts in allowconnects, trust new keys only from the
       # following ones.  This is open by default for bootstrapping.
-
-      "trustkeysfrom" slist => getvalues("override_data_trustkeysfrom"),
-      comment => "JSON-sourced: define from which machines keys can be trusted",
-      ifvarclass => isvariable("override_data_trustkeysfrom"),
-      meta => { "defvar" };
 
       "trustkeysfrom" slist => {
                                  # COMMENT THE NEXT LINE OUT AFTER ALL MACHINES HAVE BEEN BOOTSTRAPPED.
                                  "0.0.0.0/0", # allow any IP
       },
-      comment => "Define from which machines keys can be trusted",
-      ifvarclass => not(isvariable("override_data_trustkeysfrom")),
-      meta => { "defvar" };
+      comment => "Define from which machines keys can be trusted";
 
-  debian::
+    debian::
       "environment_vars"
         handle => "common_def_vars_environment_vars",
         comment => "Environment variables of the agent process. The values
@@ -137,37 +70,11 @@ bundle common def
 
       # End change #
 
-  cfengine_3_5::
+    any::::
       "dir_masterfiles" string => translatepath("$(sys.workdir)/masterfiles"),
       comment => "Define masterfiles path",
       handle => "common_def_vars_dir_masterfiles_backport";
 
-    !cfengine_3_5::
-      "dir_masterfiles" string => translatepath("$(sys.masterdir)"),
-      comment => "Define masterfiles path",
-      handle => "common_def_vars_dir_masterfiles";
-
-      "dir_reports"     string => translatepath("$(sys.workdir)/reports"),
-      comment => "Define reports path",
-      handle => "common_def_vars_dir_reports";
-
-      "dir_software"    string => translatepath("$(sys.workdir)/master_software_updates"),
-      comment => "Define software path",
-      handle => "common_def_vars_dir_software";
-
-      "dir_bin"         string => translatepath("$(sys.bindir)"),
-      comment => "Define binary path",
-      handle => "common_def_vars_dir_bin";
-
-      "dir_modules"     string => translatepath("$(sys.workdir)/modules"),
-      comment => "Define modules path",
-      handle => "common_def_vars_dir_modules";
-
-      "dir_plugins"     string => translatepath("$(sys.workdir)/plugins"),
-      comment => "Define plugins path",
-      handle => "common_def_vars_dir_plugins";
-
-    cfengine_3_5::
       "cf_apache_user" string => "apache",
       comment => "User that CFEngine Enterprise webserver runs as",
       handle => "common_def_vars_cf_apache_user";
@@ -176,22 +83,13 @@ bundle common def
       comment => "Group that CFEngine Enterprise webserver runs as",
       handle => "common_def_vars_cf_apache_group";
 
-    !cfengine_3_5::
-      "cf_apache_user" string => "cfapache",
-      comment => "User that CFEngine Enterprise webserver runs as",
-      handle => "common_def_vars_cf_cfapache_user";
-
-      "cf_apache_group" string => "cfapache",
-      comment => "Group that CFEngine Enterprise webserver runs as",
-      handle => "common_def_vars_cf_cfapache_group";
-
-      solaris::
+    solaris::
       "cf_runagent_shell"
         string  => "/usr/bin/sh",
         comment => "Define path to shell used by cf-runagent",
         handle  => "common_def_vars_solaris_cf_runagent_shell";
 
-      !(windows|solaris)::
+    !(windows|solaris)::
       "cf_runagent_shell"
         string  => "/bin/sh",
         comment => "Define path to shell used by cf-runagent",
@@ -295,25 +193,6 @@ bundle common def
       # sketch activations on a host.
       "cfengine_internal_sudoers_editing_enable" expression => "!any";
 
-      # Class defining which versions of cfengine are (not) supported
-      # by this policy version.
-      # Also note that this policy will only be run on enterprise policy_server
-      "postgresql_maintenance_supported"
-        expression => "(policy_server.enterprise.!cfengine_3_5.!enable_cfengine_enterprise_hub_ha)|(policy_server.enterprise.enable_cfengine_enterprise_hub_ha.hub_active)";
-
-      # This class is for PosgreSQL maintenance
-      # pre-defined to every Sunday at 2 a.m.
-      # This can be changed later on.
-
-      "postgresql_full_maintenance" expression => "postgresql_maintenance_supported.Sunday.Hr02.Min00_05";
-
-      # Vacuum monitoring_mg table every day (except Sunday, when vacuum is run on entire db)
-      "postgresql_monitoring_maintenance" expression => "postgresql_maintenance_supported.!Sunday.Hr02.Min00_05";
-
-      # Enable CFEngine Enterprise HA Policy
-      "enable_cfengine_enterprise_hub_ha" expression => "!any";
-      #"enable_cfengine_enterprise_hub_ha" expression => "enterprise_edition";
-
       # Enable cleanup of agent report diffs when they exceed
       # `def.max_client_history_size`
       "enable_cfe_internal_cleanup_agent_reports" -> { "cf-hub", "CFEngine Enterprise" }
@@ -325,17 +204,9 @@ bundle common def
   reports:
     DEBUG|DEBUG_def::
       "DEBUG: $(this.bundle)";
-      "$(const.t) override request $(override_vars) to '$(override_data_s_$(override_vars))'; new value '$($(override_vars))'"
-      ifvarclass => isvariable("override_data_$(override_vars)");
+      "$(const.t) Found augments file '$(augments_file)', but augments are not supported in this version"
+        ifvarclass => "have_augments_file";
 
-      "$(const.t) defined class role/byname $(extra_roles[byname][$(roles_byname_keys)]) because of classmatch('$(roles_byname_keys)')"
-      ifvarclass => "$(extra_roles[byname][$(roles_byname_keys)])";
-
-      "$(const.t) defined class role/byrole $(roles_byrole_keys) because of classmatch('$(extra_roles[byrole][$(roles_byrole_keys)])')"
-      ifvarclass => "$(roles_byrole_keys)";
-
-      "$(const.t) override class $(override_classes)";
-      "$(const.t) $(defvars) = $($(defvars))";
 }
 
 bundle common inventory_control

--- a/lib/3.6/def.cf
+++ b/lib/3.6/def.cf
@@ -1,0 +1,408 @@
+###############################################################################
+#
+# bundle common def
+#  - common/global variables and classes here
+#
+###############################################################################
+body file control
+{
+      inputs => { @(def.extra_inputs) };
+}
+
+bundle common def
+{
+  classes:
+      # all override classes are defined true
+      "$(override_classes)" expression => "any", meta => { "override" };
+
+      "have_augments_file" expression => fileexists($(augments_file)), scope => "bundle";
+
+      "augments_are_json" expression => regcmp(".+\.json", $(augments_file)), scope => "bundle";
+      "have_json_augments" and => { "have_augments_file", "augments_are_json" }, scope => "bundle";
+
+      "augments_are_yaml" expression => regcmp(".+\.yaml", $(augments_file)), scope => "bundle";
+      "have_yaml_augments" and => { "have_augments_file", "augments_are_yaml" }, scope => "bundle";
+
+      "have_roles" expression => isvariable("augments[roles]"), scope => "bundle";
+      "have_inputs" expression => isvariable("augments[inputs]"), scope => "bundle";
+
+    have_roles::
+      "$(extra_roles[byname][$(roles_byname_keys)])" expression => classmatch("$(roles_byname_keys)"), meta => { "role" };
+      "$(roles_byrole_keys)" expression => classmatch("$(extra_roles[byrole][$(roles_byrole_keys)])"), meta => { "role" };
+
+  vars:
+
+    any::
+      "augments_file" string => ifelse(fileexists("$(this.promise_dirname)/services/def.yaml"), "$(this.promise_dirname)/services/def.yaml",
+                                      "$(this.promise_dirname)/services/def.json");
+
+      "defvars" slist => variablesmatching("default:def\..*", "defvar");
+
+    have_augments_file::
+      "augments" data => readjson($(augments_file), 100k), ifvarclass => "augments_are_json";
+      #"augments" data => readyaml($(augments_file), 100k), ifvarclass => "augments_are_yaml";
+
+      "extra_inputs" slist => getvalues("augments[inputs]");
+      "override_vars" slist => getindices("augments[vars]");
+      "override_classes" slist => getvalues("augments[classes]");
+      "override_data_$(override_vars)" data => mergedata("augments[vars][$(override_vars)]");
+      "override_data_s_$(override_vars)" string => format("%S", "override_data_$(override_vars)");
+
+    !have_augments_file::
+      "extra_inputs" slist => {};
+
+    have_roles::
+      "extra_roles" data => mergedata("augments[roles]");
+      "roles_byname_keys" slist => getindices("extra_roles[byname]");
+      "roles_byrole_keys" slist => getindices("extra_roles[byrole]");
+
+    any::
+      # Begin change
+
+      # Your domain name, for use in access control
+      "domain"  string => ifelse(isvariable("override_data_domain"), "$(override_data_domain)",
+                                "$(sys.domain)"), # this default may be inaccurate!
+      comment => "Define a global domain for all hosts",
+      handle => "common_def_vars_domain",
+      meta => { "defvar" };
+
+      # Mail settings used by body executor control found in controls/cf_execd.cf
+      "mailto" string => ifelse(isvariable("override_data_mailto"), "$(override_data_mailto)",
+                               "root@$(def.domain)"),
+      meta => { "defvar" };
+
+      "mailfrom" string => ifelse(isvariable("override_data_mailfrom"), "$(override_data_mailfrom)",
+                                 "root@$(sys.uqhost).$(def.domain)"),
+      meta => { "defvar" };
+
+      "smtpserver" string => ifelse(isvariable("override_data_smtpserver"), "$(override_data_smtpserver)",
+                                   "localhost"),
+      meta => { "defvar" };
+
+      # List here the IP masks that we grant access to on the server
+
+      "acl"     slist => getvalues("override_data_acl"),
+      comment => "JSON-sourced: Define an acl for the machines to be granted accesses",
+      handle => "common_def_json_vars_acl",
+      ifvarclass => isvariable("override_data_acl"),
+      meta => { "defvar" };
+
+      "acl"     slist => {
+                           # Allow everything in my own domain.
+
+                           # Note that this:
+                           # 1. requires def.domain to be correctly set
+                           # 2. will cause a DNS lookup for every access
+                           # ".*$(def.domain)",
+
+                           # Assume /16 LAN clients to start with
+                           "$(sys.policy_hub)/16",
+
+                           #  "2001:700:700:3.*",
+                           #  "217.77.34.18",
+                           #  "217.77.34.19",
+      },
+      comment => "Define an acl for the machines to be granted accesses",
+      handle => "common_def_vars_acl",
+      ifvarclass => not(isvariable("override_data_acl")),
+      meta => { "defvar" };
+
+      # Out of the hosts in allowconnects, trust new keys only from the
+      # following ones.  This is open by default for bootstrapping.
+
+      "trustkeysfrom" slist => getvalues("override_data_trustkeysfrom"),
+      comment => "JSON-sourced: define from which machines keys can be trusted",
+      ifvarclass => isvariable("override_data_trustkeysfrom"),
+      meta => { "defvar" };
+
+      "trustkeysfrom" slist => {
+                                 # COMMENT THE NEXT LINE OUT AFTER ALL MACHINES HAVE BEEN BOOTSTRAPPED.
+                                 "0.0.0.0/0", # allow any IP
+      },
+      comment => "Define from which machines keys can be trusted",
+      ifvarclass => not(isvariable("override_data_trustkeysfrom")),
+      meta => { "defvar" };
+
+  debian::
+      "environment_vars"
+        handle => "common_def_vars_environment_vars",
+        comment => "Environment variables of the agent process. The values
+                    of environment variables are inherited by child commands.",
+        slist => {
+                   "DEBIAN_FRONTEND=noninteractive",
+                  # "APT_LISTBUGS_FRONTEND=none",
+                  # "APT_LISTCHANGES_FRONTEND=none",
+                 };
+
+      # End change #
+
+  any::
+      "dir_masterfiles" string => translatepath("$(sys.masterdir)"),
+      comment => "Define masterfiles path",
+      handle => "common_def_vars_dir_masterfiles";
+
+      "dir_reports"     string => translatepath("$(sys.workdir)/reports"),
+      comment => "Define reports path",
+      handle => "common_def_vars_dir_reports";
+
+      "dir_software"    string => translatepath("$(sys.workdir)/master_software_updates"),
+      comment => "Define software path",
+      handle => "common_def_vars_dir_software";
+
+      "dir_bin"         string => translatepath("$(sys.bindir)"),
+      comment => "Define binary path",
+      handle => "common_def_vars_dir_bin";
+
+      "dir_modules"     string => translatepath("$(sys.workdir)/modules"),
+      comment => "Define modules path",
+      handle => "common_def_vars_dir_modules";
+
+      "dir_plugins"     string => translatepath("$(sys.workdir)/plugins"),
+      comment => "Define plugins path",
+      handle => "common_def_vars_dir_plugins";
+
+      "cf_apache_user" string => "cfapache",
+      comment => "User that CFEngine Enterprise webserver runs as",
+      handle => "common_def_vars_cf_cfapache_user";
+
+      "cf_apache_group" string => "cfapache",
+      comment => "Group that CFEngine Enterprise webserver runs as",
+      handle => "common_def_vars_cf_cfapache_group";
+
+    solaris::
+      "cf_runagent_shell"
+        string  => "/usr/bin/sh",
+        comment => "Define path to shell used by cf-runagent",
+        handle  => "common_def_vars_solaris_cf_runagent_shell";
+
+    !(windows|solaris)::
+      "cf_runagent_shell"
+        string  => "/bin/sh",
+        comment => "Define path to shell used by cf-runagent",
+        handle  => "common_def_vars_cf_runagent_shell";
+
+    any::
+      "base_log_files" slist =>
+      {
+        "$(sys.workdir)/cf3.$(sys.uqhost).runlog",
+        "$(sys.workdir)/promise_summary.log",
+      };
+
+      "enterprise_log_files" slist =>
+      {
+        "$(sys.workdir)/cf_notkept.log",
+        "$(sys.workdir)/cf_repair.log",
+        "$(sys.workdir)/state/cf_value.log",
+        "$(sys.workdir)/outputs/dc-scripts.log",
+      };
+
+      "hub_log_files" slist =>
+      {
+        "$(sys.workdir)/httpd/logs/access_log", # Mission Portal
+        "$(sys.workdir)/httpd/logs/error_log", # Mission Portal
+      };
+
+      "max_client_history_size" -> { "cf-hub", "CFEngine Enterprise" }
+        int => "50M",
+        comment => "The threshold of report diffs which will trigger purging of
+                    diff files.";
+
+    enterprise.!am_policy_hub::
+      # CFEngine's own log files
+      "cfe_log_files" slist => { @(base_log_files), @(enterprise_log_files) };
+
+    enterprise.am_policy_hub::
+      # CFEngine's own log files
+      "cfe_log_files" slist => { @(base_log_files), @(enterprise_log_files), @(hub_log_files) };
+
+    !enterprise::
+      # CFEngine's own log files
+      "cfe_log_files" slist => { @(base_log_files) };
+
+    any::
+      "cfe_log_dirs" slist =>
+      {
+        "$(sys.workdir)/outputs",
+        "$(sys.workdir)/reports",
+      };
+
+    # enable_cfengine_enterprise_hub_ha is defined below 
+    # Disabled by default
+
+    enable_cfengine_enterprise_hub_ha::
+      "policy_servers" slist => {"$(sys.policy_hub)", @(ha_def.ips)};
+
+    !enable_cfengine_enterprise_hub_ha::
+      "policy_servers" slist => {"$(sys.policy_hub)"};
+
+  classes:
+
+      ### Enable special features policies. Set to "any" to enable.
+
+      # Auto-load files in "services/autorun" and run bundles tagged "autorun".
+      # Disabled by default!
+      "services_autorun" expression => "!any";
+
+      # Internal CFEngine log files rotation
+      "cfengine_internal_rotate_logs" expression => "any";
+
+      # Disable agent email output
+      "cfengine_internal_agent_email" expression => "any";
+
+      # Transfer policies and binaries with encryption
+      # you can also request it from the command line with
+      # -Dcfengine_internal_encrypt_transfers
+
+      # NOTE THAT THIS CLASS ALSO NEEDS TO BE SET IN update.cf
+
+      "cfengine_internal_encrypt_transfers" expression => "!any";
+
+      # Purge policies that don't exist on the server side.
+      # you can also request it from the command line with
+      # -Dcfengine_internal_purge_policies
+
+      # NOTE THAT THIS CLASS ALSO NEEDS TO BE SET IN update.cf
+
+      "cfengine_internal_purge_policies" expression => "!any";
+
+      # Preserve permissions of the policy server's masterfiles.
+      # you can also request it from the command line with
+      # -Dcfengine_internal_preserve_permissions
+
+      # NOTE THAT THIS CLASS ALSO NEEDS TO BE SET IN update.cf
+
+      "cfengine_internal_preserve_permissions" expression => "!any";
+
+      # Allow the hub to edit sudoers in order for the Apache user to
+      # run passwordless sudo cf-runagent. Enable this if you want the
+      # Mission Portal to be able to troubleshoot failed Design Center
+      # sketch activations on a host.
+      "cfengine_internal_sudoers_editing_enable" expression => "!any";
+
+      # Class defining which versions of cfengine are (not) supported
+      # by this policy version.
+      # Also note that this policy will only be run on enterprise policy_server
+      "postgresql_maintenance_supported"
+        expression => "(policy_server.enterprise.!enable_cfengine_enterprise_hub_ha)|(policy_server.enterprise.enable_cfengine_enterprise_hub_ha.hub_active)";
+
+      # This class is for PosgreSQL maintenance
+      # pre-defined to every Sunday at 2 a.m.
+      # This can be changed later on.
+
+      "postgresql_full_maintenance" expression => "postgresql_maintenance_supported.Sunday.Hr02.Min00_05";
+
+      # Vacuum monitoring_mg table every day (except Sunday, when vacuum is run on entire db)
+      "postgresql_monitoring_maintenance" expression => "postgresql_maintenance_supported.!Sunday.Hr02.Min00_05";
+
+      # Enable CFEngine Enterprise HA Policy
+      "enable_cfengine_enterprise_hub_ha" expression => "!any";
+      #"enable_cfengine_enterprise_hub_ha" expression => "enterprise_edition";
+
+      # Enable cleanup of agent report diffs when they exceed
+      # `def.max_client_history_size`
+      "enable_cfe_internal_cleanup_agent_reports" -> { "cf-hub", "CFEngine Enterprise" }
+        expression => "enterprise_edition",
+        comment => "If reports are not collected for an extended period of time
+                    the disk may fill up or cause additional collection
+                    issues.";
+
+  reports:
+    DEBUG|DEBUG_def::
+      "DEBUG: $(this.bundle)";
+      "$(const.t) override request $(override_vars) to '$(override_data_s_$(override_vars))'; new value '$($(override_vars))'"
+      ifvarclass => isvariable("override_data_$(override_vars)");
+
+      "$(const.t) defined class role/byname $(extra_roles[byname][$(roles_byname_keys)]) because of classmatch('$(roles_byname_keys)')"
+      ifvarclass => "$(extra_roles[byname][$(roles_byname_keys)])";
+
+      "$(const.t) defined class role/byrole $(roles_byrole_keys) because of classmatch('$(extra_roles[byrole][$(roles_byrole_keys)])')"
+      ifvarclass => "$(roles_byrole_keys)";
+
+      "$(const.t) override class $(override_classes)";
+      "$(const.t) $(defvars) = $($(defvars))";
+}
+
+bundle common inventory_control
+# @brief Inventory control bundle
+#
+# This common bundle is for controlling whether some inventory bundles
+# are disabled.
+{
+  vars:
+      "dmidecoder" string => "/usr/sbin/dmidecode";
+      "lldpctl_exec" string => "/usr/bin/lldpctl";
+      "lsb_exec" string => "/usr/bin/lsb_release";
+      "mtab" string => "/etc/mtab";
+      "proc" string => "/proc";
+
+  classes:
+      # setting this disables all the inventory modules except package_refresh
+      "disable_inventory" expression => "!any";
+
+      # disable specific inventory modules below
+
+      # by default disable the LSB inventory if the general inventory
+      # is disabled or the binary is missing.  Note that the LSB
+      # binary is typically not very fast.
+      "disable_inventory_lsb" expression => "disable_inventory";
+      "disable_inventory_lsb" not => fileexists($(lsb_exec));
+
+      # by default disable the dmidecode inventory if the general
+      # inventory is disabled or the binary does not exist.  Note that
+      # typically this is a very fast binary.
+      "disable_inventory_dmidecode" expression => "disable_inventory";
+      "disable_inventory_dmidecode" not => fileexists($(dmidecoder));
+
+      # by default disable the LLDP inventory if the general inventory
+      # is disabled or the binary does not exist.  Note that typically
+      # this is a reasonably fast binary but still may require network
+      # I/O.
+      "disable_inventory_LLDP" expression => "disable_inventory";
+      "disable_inventory_LLDP" not => fileexists($(lldpctl_exec));
+
+      # by default run the package inventory refresh every time, even
+      # if disable_inventory is set
+      "disable_inventory_package_refresh" expression => "!any";
+
+      # by default disable the mtab inventory if the general inventory
+      # is disabled or $(mtab) is missing.  Note that this is very
+      # fast.
+      "disable_inventory_mtab" expression => "disable_inventory";
+      "disable_inventory_mtab" not => fileexists($(mtab));
+
+      # by default disable the fstab inventory if the general
+      # inventory is disabled or $(sys.fstab) is missing.  Note that
+      # this is very fast.
+      "disable_inventory_fstab" expression => "disable_inventory";
+      "disable_inventory_fstab" not => fileexists($(sys.fstab));
+
+      # by default disable the proc inventory if the general
+      # inventory is disabled or /proc is missing.  Note that
+      # this is typically fast.
+      "disable_inventory_proc" expression => "disable_inventory";
+      "disable_inventory_proc" not => isdir($(proc));
+
+      # by default don't run the CMDB integration every time, even if
+      # disable_inventory is not set
+      "disable_inventory_cmdb" expression => "any";
+
+  reports:
+    verbose_mode.disable_inventory::
+      "$(this.bundle): All inventory modules disabled";
+    verbose_mode.!disable_inventory_lsb::
+      "$(this.bundle): LSB module enabled";
+    verbose_mode.!disable_inventory_dmidecode::
+      "$(this.bundle): dmidecode module enabled";
+    verbose_mode.!disable_inventory_LLDP::
+      "$(this.bundle): LLDP module enabled";
+    verbose_mode.!disable_inventory_mtab::
+      "$(this.bundle): mtab module enabled";
+    verbose_mode.!disable_inventory_fstab::
+      "$(this.bundle): fstab module enabled";
+    verbose_mode.!disable_inventory_proc::
+      "$(this.bundle): proc module enabled";
+    verbose_mode.!disable_inventory_package_refresh::
+      "$(this.bundle): package_refresh module enabled";
+    verbose_mode.!disable_inventory_cmdb::
+      "$(this.bundle): CMDB module enabled";
+}

--- a/lib/3.7/def.cf
+++ b/lib/3.7/def.cf
@@ -1,0 +1,408 @@
+###############################################################################
+#
+# bundle common def
+#  - common/global variables and classes here
+#
+###############################################################################
+body file control
+{
+      inputs => { @(def.extra_inputs) };
+}
+
+bundle common def
+{
+  classes:
+      # all override classes are defined true
+      "$(override_classes)" expression => "any", meta => { "override" };
+
+      "have_augments_file" expression => fileexists($(augments_file)), scope => "bundle";
+
+      "augments_are_json" expression => regcmp(".+\.json", $(augments_file)), scope => "bundle";
+      "have_json_augments" and => { "have_augments_file", "augments_are_json" }, scope => "bundle";
+
+      "augments_are_yaml" expression => regcmp(".+\.yaml", $(augments_file)), scope => "bundle";
+      "have_yaml_augments" and => { "have_augments_file", "augments_are_yaml" }, scope => "bundle";
+
+      "have_roles" expression => isvariable("augments[roles]"), scope => "bundle";
+      "have_inputs" expression => isvariable("augments[inputs]"), scope => "bundle";
+
+    have_roles::
+      "$(extra_roles[byname][$(roles_byname_keys)])" expression => classmatch("$(roles_byname_keys)"), meta => { "role" };
+      "$(roles_byrole_keys)" expression => classmatch("$(extra_roles[byrole][$(roles_byrole_keys)])"), meta => { "role" };
+
+  vars:
+
+    any::
+      "augments_file" string => ifelse(fileexists("$(this.promise_dirname)/services/def.yaml"), "$(this.promise_dirname)/services/def.yaml",
+                                      "$(this.promise_dirname)/services/def.json");
+
+      "defvars" slist => variablesmatching("default:def\..*", "defvar");
+
+    have_augments_file::
+      "augments" data => readjson($(augments_file), 100k), ifvarclass => "augments_are_json";
+      #"augments" data => readyaml($(augments_file), 100k), ifvarclass => "augments_are_yaml";
+
+      "extra_inputs" slist => getvalues("augments[inputs]");
+      "override_vars" slist => getindices("augments[vars]");
+      "override_classes" slist => getvalues("augments[classes]");
+      "override_data_$(override_vars)" data => mergedata("augments[vars][$(override_vars)]");
+      "override_data_s_$(override_vars)" string => format("%S", "override_data_$(override_vars)");
+
+    !have_augments_file::
+      "extra_inputs" slist => {};
+
+    have_roles::
+      "extra_roles" data => mergedata("augments[roles]");
+      "roles_byname_keys" slist => getindices("extra_roles[byname]");
+      "roles_byrole_keys" slist => getindices("extra_roles[byrole]");
+
+    any::
+      # Begin change
+
+      # Your domain name, for use in access control
+      "domain"  string => ifelse(isvariable("override_data_domain"), "$(override_data_domain)",
+                                "$(sys.domain)"), # this default may be inaccurate!
+      comment => "Define a global domain for all hosts",
+      handle => "common_def_vars_domain",
+      meta => { "defvar" };
+
+      # Mail settings used by body executor control found in controls/cf_execd.cf
+      "mailto" string => ifelse(isvariable("override_data_mailto"), "$(override_data_mailto)",
+                               "root@$(def.domain)"),
+      meta => { "defvar" };
+
+      "mailfrom" string => ifelse(isvariable("override_data_mailfrom"), "$(override_data_mailfrom)",
+                                 "root@$(sys.uqhost).$(def.domain)"),
+      meta => { "defvar" };
+
+      "smtpserver" string => ifelse(isvariable("override_data_smtpserver"), "$(override_data_smtpserver)",
+                                   "localhost"),
+      meta => { "defvar" };
+
+      # List here the IP masks that we grant access to on the server
+
+      "acl"     slist => getvalues("override_data_acl"),
+      comment => "JSON-sourced: Define an acl for the machines to be granted accesses",
+      handle => "common_def_json_vars_acl",
+      ifvarclass => isvariable("override_data_acl"),
+      meta => { "defvar" };
+
+      "acl"     slist => {
+                           # Allow everything in my own domain.
+
+                           # Note that this:
+                           # 1. requires def.domain to be correctly set
+                           # 2. will cause a DNS lookup for every access
+                           # ".*$(def.domain)",
+
+                           # Assume /16 LAN clients to start with
+                           "$(sys.policy_hub)/16",
+
+                           #  "2001:700:700:3.*",
+                           #  "217.77.34.18",
+                           #  "217.77.34.19",
+      },
+      comment => "Define an acl for the machines to be granted accesses",
+      handle => "common_def_vars_acl",
+      ifvarclass => not(isvariable("override_data_acl")),
+      meta => { "defvar" };
+
+      # Out of the hosts in allowconnects, trust new keys only from the
+      # following ones.  This is open by default for bootstrapping.
+
+      "trustkeysfrom" slist => getvalues("override_data_trustkeysfrom"),
+      comment => "JSON-sourced: define from which machines keys can be trusted",
+      ifvarclass => isvariable("override_data_trustkeysfrom"),
+      meta => { "defvar" };
+
+      "trustkeysfrom" slist => {
+                                 # COMMENT THE NEXT LINE OUT AFTER ALL MACHINES HAVE BEEN BOOTSTRAPPED.
+                                 "0.0.0.0/0", # allow any IP
+      },
+      comment => "Define from which machines keys can be trusted",
+      ifvarclass => not(isvariable("override_data_trustkeysfrom")),
+      meta => { "defvar" };
+
+    debian::
+      "environment_vars"
+        handle => "common_def_vars_environment_vars",
+        comment => "Environment variables of the agent process. The values
+                    of environment variables are inherited by child commands.",
+        slist => {
+                   "DEBIAN_FRONTEND=noninteractive",
+                  # "APT_LISTBUGS_FRONTEND=none",
+                  # "APT_LISTCHANGES_FRONTEND=none",
+                 };
+
+      # End change #
+
+    any::
+      "dir_masterfiles" string => translatepath("$(sys.masterdir)"),
+      comment => "Define masterfiles path",
+      handle => "common_def_vars_dir_masterfiles";
+
+      "dir_reports"     string => translatepath("$(sys.workdir)/reports"),
+      comment => "Define reports path",
+      handle => "common_def_vars_dir_reports";
+
+      "dir_software"    string => translatepath("$(sys.workdir)/master_software_updates"),
+      comment => "Define software path",
+      handle => "common_def_vars_dir_software";
+
+      "dir_bin"         string => translatepath("$(sys.bindir)"),
+      comment => "Define binary path",
+      handle => "common_def_vars_dir_bin";
+
+      "dir_modules"     string => translatepath("$(sys.workdir)/modules"),
+      comment => "Define modules path",
+      handle => "common_def_vars_dir_modules";
+
+      "dir_plugins"     string => translatepath("$(sys.workdir)/plugins"),
+      comment => "Define plugins path",
+      handle => "common_def_vars_dir_plugins";
+
+      "cf_apache_user" string => "cfapache",
+      comment => "User that CFEngine Enterprise webserver runs as",
+      handle => "common_def_vars_cf_cfapache_user";
+
+      "cf_apache_group" string => "cfapache",
+      comment => "Group that CFEngine Enterprise webserver runs as",
+      handle => "common_def_vars_cf_cfapache_group";
+
+    solaris::
+      "cf_runagent_shell"
+        string  => "/usr/bin/sh",
+        comment => "Define path to shell used by cf-runagent",
+        handle  => "common_def_vars_solaris_cf_runagent_shell";
+
+    !(windows|solaris)::
+      "cf_runagent_shell"
+        string  => "/bin/sh",
+        comment => "Define path to shell used by cf-runagent",
+        handle  => "common_def_vars_cf_runagent_shell";
+
+    any::
+      "base_log_files" slist =>
+      {
+        "$(sys.workdir)/cf3.$(sys.uqhost).runlog",
+        "$(sys.workdir)/promise_summary.log",
+      };
+
+      "enterprise_log_files" slist =>
+      {
+        "$(sys.workdir)/cf_notkept.log",
+        "$(sys.workdir)/cf_repair.log",
+        "$(sys.workdir)/state/cf_value.log",
+        "$(sys.workdir)/outputs/dc-scripts.log",
+      };
+
+      "hub_log_files" slist =>
+      {
+        "$(sys.workdir)/httpd/logs/access_log", # Mission Portal
+        "$(sys.workdir)/httpd/logs/error_log", # Mission Portal
+      };
+
+      "max_client_history_size" -> { "cf-hub", "CFEngine Enterprise" }
+        int => "50M",
+        comment => "The threshold of report diffs which will trigger purging of
+                    diff files.";
+
+    enterprise.!am_policy_hub::
+      # CFEngine's own log files
+      "cfe_log_files" slist => { @(base_log_files), @(enterprise_log_files) };
+
+    enterprise.am_policy_hub::
+      # CFEngine's own log files
+      "cfe_log_files" slist => { @(base_log_files), @(enterprise_log_files), @(hub_log_files) };
+
+    !enterprise::
+      # CFEngine's own log files
+      "cfe_log_files" slist => { @(base_log_files) };
+
+    any::
+      "cfe_log_dirs" slist =>
+      {
+        "$(sys.workdir)/outputs",
+        "$(sys.workdir)/reports",
+      };
+
+    # enable_cfengine_enterprise_hub_ha is defined below 
+    # Disabled by default
+
+    enable_cfengine_enterprise_hub_ha::
+      "policy_servers" slist => {"$(sys.policy_hub)", @(ha_def.ips)};
+
+    !enable_cfengine_enterprise_hub_ha::
+      "policy_servers" slist => {"$(sys.policy_hub)"};
+
+  classes:
+
+      ### Enable special features policies. Set to "any" to enable.
+
+      # Auto-load files in "services/autorun" and run bundles tagged "autorun".
+      # Disabled by default!
+      "services_autorun" expression => "!any";
+
+      # Internal CFEngine log files rotation
+      "cfengine_internal_rotate_logs" expression => "any";
+
+      # Disable agent email output
+      "cfengine_internal_agent_email" expression => "any";
+
+      # Transfer policies and binaries with encryption
+      # you can also request it from the command line with
+      # -Dcfengine_internal_encrypt_transfers
+
+      # NOTE THAT THIS CLASS ALSO NEEDS TO BE SET IN update.cf
+
+      "cfengine_internal_encrypt_transfers" expression => "!any";
+
+      # Purge policies that don't exist on the server side.
+      # you can also request it from the command line with
+      # -Dcfengine_internal_purge_policies
+
+      # NOTE THAT THIS CLASS ALSO NEEDS TO BE SET IN update.cf
+
+      "cfengine_internal_purge_policies" expression => "!any";
+
+      # Preserve permissions of the policy server's masterfiles.
+      # you can also request it from the command line with
+      # -Dcfengine_internal_preserve_permissions
+
+      # NOTE THAT THIS CLASS ALSO NEEDS TO BE SET IN update.cf
+
+      "cfengine_internal_preserve_permissions" expression => "!any";
+
+      # Allow the hub to edit sudoers in order for the Apache user to
+      # run passwordless sudo cf-runagent. Enable this if you want the
+      # Mission Portal to be able to troubleshoot failed Design Center
+      # sketch activations on a host.
+      "cfengine_internal_sudoers_editing_enable" expression => "!any";
+
+      # Class defining which versions of cfengine are (not) supported
+      # by this policy version.
+      # Also note that this policy will only be run on enterprise policy_server
+      "postgresql_maintenance_supported"
+        expression => "(policy_server.enterprise.!enable_cfengine_enterprise_hub_ha)|(policy_server.enterprise.enable_cfengine_enterprise_hub_ha.hub_active)";
+
+      # This class is for PosgreSQL maintenance
+      # pre-defined to every Sunday at 2 a.m.
+      # This can be changed later on.
+
+      "postgresql_full_maintenance" expression => "postgresql_maintenance_supported.Sunday.Hr02.Min00_05";
+
+      # Vacuum monitoring_mg table every day (except Sunday, when vacuum is run on entire db)
+      "postgresql_monitoring_maintenance" expression => "postgresql_maintenance_supported.!Sunday.Hr02.Min00_05";
+
+      # Enable CFEngine Enterprise HA Policy
+      "enable_cfengine_enterprise_hub_ha" expression => "!any";
+      #"enable_cfengine_enterprise_hub_ha" expression => "enterprise_edition";
+
+      # Enable cleanup of agent report diffs when they exceed
+      # `def.max_client_history_size`
+      "enable_cfe_internal_cleanup_agent_reports" -> { "cf-hub", "CFEngine Enterprise" }
+        expression => "enterprise_edition",
+        comment => "If reports are not collected for an extended period of time
+                    the disk may fill up or cause additional collection
+                    issues.";
+
+  reports:
+    DEBUG|DEBUG_def::
+      "DEBUG: $(this.bundle)";
+      "$(const.t) override request $(override_vars) to '$(override_data_s_$(override_vars))'; new value '$($(override_vars))'"
+      ifvarclass => isvariable("override_data_$(override_vars)");
+
+      "$(const.t) defined class role/byname $(extra_roles[byname][$(roles_byname_keys)]) because of classmatch('$(roles_byname_keys)')"
+      ifvarclass => "$(extra_roles[byname][$(roles_byname_keys)])";
+
+      "$(const.t) defined class role/byrole $(roles_byrole_keys) because of classmatch('$(extra_roles[byrole][$(roles_byrole_keys)])')"
+      ifvarclass => "$(roles_byrole_keys)";
+
+      "$(const.t) override class $(override_classes)";
+      "$(const.t) $(defvars) = $($(defvars))";
+}
+
+bundle common inventory_control
+# @brief Inventory control bundle
+#
+# This common bundle is for controlling whether some inventory bundles
+# are disabled.
+{
+  vars:
+      "dmidecoder" string => "/usr/sbin/dmidecode";
+      "lldpctl_exec" string => "/usr/bin/lldpctl";
+      "lsb_exec" string => "/usr/bin/lsb_release";
+      "mtab" string => "/etc/mtab";
+      "proc" string => "/proc";
+
+  classes:
+      # setting this disables all the inventory modules except package_refresh
+      "disable_inventory" expression => "!any";
+
+      # disable specific inventory modules below
+
+      # by default disable the LSB inventory if the general inventory
+      # is disabled or the binary is missing.  Note that the LSB
+      # binary is typically not very fast.
+      "disable_inventory_lsb" expression => "disable_inventory";
+      "disable_inventory_lsb" not => fileexists($(lsb_exec));
+
+      # by default disable the dmidecode inventory if the general
+      # inventory is disabled or the binary does not exist.  Note that
+      # typically this is a very fast binary.
+      "disable_inventory_dmidecode" expression => "disable_inventory";
+      "disable_inventory_dmidecode" not => fileexists($(dmidecoder));
+
+      # by default disable the LLDP inventory if the general inventory
+      # is disabled or the binary does not exist.  Note that typically
+      # this is a reasonably fast binary but still may require network
+      # I/O.
+      "disable_inventory_LLDP" expression => "disable_inventory";
+      "disable_inventory_LLDP" not => fileexists($(lldpctl_exec));
+
+      # by default run the package inventory refresh every time, even
+      # if disable_inventory is set
+      "disable_inventory_package_refresh" expression => "!any";
+
+      # by default disable the mtab inventory if the general inventory
+      # is disabled or $(mtab) is missing.  Note that this is very
+      # fast.
+      "disable_inventory_mtab" expression => "disable_inventory";
+      "disable_inventory_mtab" not => fileexists($(mtab));
+
+      # by default disable the fstab inventory if the general
+      # inventory is disabled or $(sys.fstab) is missing.  Note that
+      # this is very fast.
+      "disable_inventory_fstab" expression => "disable_inventory";
+      "disable_inventory_fstab" not => fileexists($(sys.fstab));
+
+      # by default disable the proc inventory if the general
+      # inventory is disabled or /proc is missing.  Note that
+      # this is typically fast.
+      "disable_inventory_proc" expression => "disable_inventory";
+      "disable_inventory_proc" not => isdir($(proc));
+
+      # by default don't run the CMDB integration every time, even if
+      # disable_inventory is not set
+      "disable_inventory_cmdb" expression => "any";
+
+  reports:
+    verbose_mode.disable_inventory::
+      "$(this.bundle): All inventory modules disabled";
+    verbose_mode.!disable_inventory_lsb::
+      "$(this.bundle): LSB module enabled";
+    verbose_mode.!disable_inventory_dmidecode::
+      "$(this.bundle): dmidecode module enabled";
+    verbose_mode.!disable_inventory_LLDP::
+      "$(this.bundle): LLDP module enabled";
+    verbose_mode.!disable_inventory_mtab::
+      "$(this.bundle): mtab module enabled";
+    verbose_mode.!disable_inventory_fstab::
+      "$(this.bundle): fstab module enabled";
+    verbose_mode.!disable_inventory_proc::
+      "$(this.bundle): proc module enabled";
+    verbose_mode.!disable_inventory_package_refresh::
+      "$(this.bundle): package_refresh module enabled";
+    verbose_mode.!disable_inventory_cmdb::
+      "$(this.bundle): CMDB module enabled";
+}

--- a/promises.cf
+++ b/promises.cf
@@ -32,7 +32,7 @@ body common control
 
       inputs => {
                  # File definition for global variables and classes
-                  "def.cf",
+                  "lib/$(sys.cf_version_major).$(sys.cf_version_minor)/def.cf",
 
                 # Inventory policy
                   @(inventory.inputs),


### PR DESCRIPTION
In order to maintain backwards compatibility for 2 minor versions we
need to load version specific def files. 3.5 does not have the readjson
function. It is likely that in the future we will want to add something
else that is not backwards compatible as well.
