### PR TITLE
Remove: Extra def.json and yaml from 3.6 upate inputs

### DIFF
--- a/lib/3.6/def.cf
+++ b/lib/3.6/def.cf
@@ -25,9 +25,7 @@ bundle common def
   vars:
 
     any::
-      # use lib/x.y/def.json first, then def.json
-      "augments_file" string => ifelse(fileexists("$(this.promise_dirname)/def.json"), "$(this.promise_dirname)/def.json",
-                                                 "$(this.promise_dirname)/../../def.json");
+      "augments_file" string => "$(this.promise_dirname)/../../def.json";
 
       "defvars" slist => variablesmatching("default:def\..*", "defvar");
 

--- a/lib/3.6/update_def.cf
+++ b/lib/3.6/update_def.cf
@@ -9,9 +9,7 @@ bundle common update_def
   vars:
       "current_version" string => "3.7.0";
     any::
-      # use lib/x.y/def.json first, then def.json
-      "augments_file" string => ifelse(fileexists("$(this.promise_dirname)/def.json"), "$(this.promise_dirname)/def.json",
-                                                 "$(this.promise_dirname)/../../def.json");
+      "augments_file" string => "$(this.promise_dirname)/../../def.json";
 
       "defvars" slist => variablesmatching("default:update_def\..*", "defvar");
 
@@ -34,7 +32,7 @@ bundle common update_def
 
       "input_name_patterns" slist => { ".*\.cf",".*\.dat",".*\.txt", ".*\.conf", ".*\.mustache",
                                        ".*\.sh", ".*\.pl", ".*\.py", ".*\.rb",
-                                       "cf_promises_release_id", ".*\.json", ".*\.yaml" },
+                                       "cf_promises_release_id", ".*\.json" },
       comment => "Filename patterns to match when updating the policy (see update/update_policy.cf)",
       handle => "common_def_vars_input_name_patterns",
       ifvarclass => not(isvariable("override_data_input_name_patterns")),

--- a/lib/3.7/def.cf
+++ b/lib/3.7/def.cf
@@ -25,9 +25,7 @@ bundle common def
   vars:
 
     any::
-      # use lib/x.y/def.json first, then def.json
-      "augments_file" string => ifelse(fileexists("$(this.promise_dirname)/def.json"), "$(this.promise_dirname)/def.json",
-                                                 "$(this.promise_dirname)/../../def.json");
+      "augments_file" string => "$(this.promise_dirname)/../../def.json";
 
       "defvars" slist => variablesmatching("default:def\..*", "defvar");
 

--- a/lib/3.7/update_def.cf
+++ b/lib/3.7/update_def.cf
@@ -9,9 +9,7 @@ bundle common update_def
   vars:
       "current_version" string => "3.7.0";
     any::
-      # use lib/x.y/def.json first, then def.json
-      "augments_file" string => ifelse(fileexists("$(this.promise_dirname)/def.json"), "$(this.promise_dirname)/def.json",
-                                                 "$(this.promise_dirname)/../../def.json");
+      "augments_file" string => "$(this.promise_dirname)/../../def.json";
 
       "defvars" slist => variablesmatching("default:update_def\..*", "defvar");
 


### PR DESCRIPTION
Extra def.json in lib only adds extra complexity. It may make sense in the
future to merge def.json with something outside of masterfiles (like data
sourced from a CMDB) but for now it seems to add little.

3.6 has no yaml support, so probably it makes little sense for 3.6 agents to
download YAML. Besides it can be overridden in def.json now so even if a user
wants it, it wont require a change in policy.
